### PR TITLE
Fix the odd colored navigation bar

### DIFF
--- a/batTheme.css
+++ b/batTheme.css
@@ -502,6 +502,11 @@ div::-webkit-scrollbar {
         font-size: 12px;
     }
 
+    /* Top Bar*/
+    .navigation-bar{
+        background-color: var(--main-background-c);
+    }
+
     /* Documents List */
     
     .ReactVirtualized__Table__headerRow {   


### PR DESCRIPTION
The navigation bar at the top, which contains the back and forward buttons, was not consistent with the rest of theme, I added css to make it the same color as the background color